### PR TITLE
Subspecies fixes

### DIFF
--- a/monsters.json
+++ b/monsters.json
@@ -4867,7 +4867,7 @@
       "type": "Elder Dragon",
       "isLarge": true,
       "subSpecies": [
-        "Rusted Jushala Daora"
+        "Rusted Kushala Daora"
       ],
       "elements": [
         "Dragon",

--- a/monsters.json
+++ b/monsters.json
@@ -6235,9 +6235,6 @@
       "name": "Purple Ludroth",
       "type": "Leviathan",
       "isLarge": true,
-      "subSpecies": [
-        "Glacial Agnaktor"
-      ],
       "ailments": [
         "Poison",
         "Noxious Poison"


### PR DESCRIPTION
Fix `Glacial Agnaktor` being listed as a `Purple Ludroth` subspecies.
Fix `Rusted Kushala Daora` being misspelled as `Rusted Jushala Daora` once.