### PR TITLE
MHWI Brute Tigrex

### DIFF
--- a/monsters.json
+++ b/monsters.json
@@ -1752,6 +1752,11 @@
           "info": "A black Tigrex subspecies. The force and range of its howl is even more fearsome than that of its cousins."
         },
         {
+          "game": "Monster Hunter World",
+          "image": "MHWI-Brute_Tigrex_Icon.png",
+          "info": "Blackish brown scales and a stronger roar set this Tigrex subspecies apart. Extremely aggressive, even by Tigrex standards."
+        },
+        {
           "game": "Monster Hunter Stories 2",
           "image": "MHST2-Brute_Tigrex_Icon.png",
           "info": "A black Tigrex subspecies. The force and range of its howl is even more fearsome than that of its cousins."


### PR DESCRIPTION
Entry for MHW (specifically Iceborne) was missing for Brute Tigrex.
Image was already present.